### PR TITLE
Fix: typecast multiDomainDMSData.java

### DIFF
--- a/ES2_2023-2_DSMEditor/src/main/java/Matrices/Data/MultiDomainDSMData.java
+++ b/ES2_2023-2_DSMEditor/src/main/java/Matrices/Data/MultiDomainDSMData.java
@@ -784,10 +784,10 @@ public class MultiDomainDSMData extends AbstractDSMData implements IZoomable, IP
             domainRows.sort(Comparator.comparing(DSMItem::getSortIndex));
             domainCols.sort(Comparator.comparing(DSMItem::getSortIndex));
             for(int i=0; i<domainRows.size(); i++) {  // reset row sort Indices 1 -> n
-                setItemSortIndex(domainRows.get(i), i + 1);
+                setItemSortIndex(domainRows.get(i), i + 1.0);
             }
             for(int i=0; i<domainCols.size(); i++) {  // reset col sort Indices 1 -> n
-                setItemSortIndex(domainCols.get(i), i + 1);
+                setItemSortIndex(domainCols.get(i), i + 1.0);
             }
         }
     }

--- a/ES2_2023-2_DSMEditor/src/main/java/Matrices/Data/MultiDomainDSMData.java
+++ b/ES2_2023-2_DSMEditor/src/main/java/Matrices/Data/MultiDomainDSMData.java
@@ -611,7 +611,7 @@ public class MultiDomainDSMData extends AbstractDSMData implements IZoomable, IP
      * @param domain  the domain for the item (for MDMs this method should be used because item domains cannot be changed)
      */
     public void createItem(String name, Grouping domain) {
-        double index = (int)getMaxSortIndex(domain) + 1;  // cast to int to remove the decimal place so that the index will be a whole number
+        double index = (int)getMaxSortIndex(domain) + 1.0;  // cast to int to remove the decimal place so that the index will be a whole number
 
         DSMItem rowItem = new DSMItem(index, name);
         DSMItem colItem = new DSMItem(index, name);


### PR DESCRIPTION
11 issue from SonarCloud: Cast one of the operands of this addition operation to a "double".